### PR TITLE
Adding Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "tmconnect/acf-column-field",
-    "description": "Advanced Custom Fields plugin: Column Field",
+    "description": "Adds an Advanced Custom Field field to arrange ACF fields into columns. This plugin needs the installation/activation of Advanced Custom Fields V5.",
     "keywords": ["wordpress", "plugin"],
     "type": "wordpress-plugin",
     "homepage": "https://github.com/tmconnect/ACF-Column-Field",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "tmconnect/acf-column-field",
+    "description": "Advanced Custom Fields plugin: Column Field",
+    "keywords": ["wordpress", "plugin"],
+    "type": "wordpress-plugin",
+    "homepage": "https://github.com/tmconnect/ACF-Column-Field",
+    "authors": [
+        {
+            "name": "Thomas Meyer",
+            "homepage": "www.dreihochzwo.de"
+        }
+     ],
+    "license": "GPLv2 or later",
+    "require": {
+    "composer/installers": "v1.0.7"
+    }
+}


### PR DESCRIPTION
Would like to add basic composer support for this plugin. Composer is dependency manager. It is easy to use, all dependency are defined in a single place and consistent across team and servers. Having Composer support does not influence work of original plugin in any way.

For more info on Composer and Wordpress: https://roots.io/using-composer-with-wordpress/